### PR TITLE
Improve S4 parameterization

### DIFF
--- a/s4/s4.py
+++ b/s4/s4.py
@@ -1207,9 +1207,9 @@ class S4Layer(nn.Module):
         self.p = self.param("p", hippo_p_initializer, (self.N,))
         self.B = self.param("B", hippo_B_initializer, (self.N, 1))
         # C should be init as standard normal
-        self.Ct = self.param("Ct", normal(), (1, self.N, 2))
+        self.Ct = self.param("Ct", normal(stddev=1.0), (1, self.N, 2))
         self.Ct = self.Ct[..., 0] + 1j * self.Ct[..., 1]
-        self.D = self.param("D", uniform(), (1,))
+        self.D = self.param("D", normal(stddev=1.0), (1,))
         self.step = np.exp(self.param("log_step", log_step_initializer(), (1,)))
 
         if not self.decode:

--- a/s4/train.py
+++ b/s4/train.py
@@ -102,7 +102,7 @@ def create_train_state(
         #   > Solution: Use Optax.multi_transform!
         s4_fn = map_nested_fn(
             lambda k, _: "s4"
-            if k in ["B", "Ct", "D", "log_step", "W"]
+            if k in ["Lambda", "p", "B", "log_step", "W"]
             else ("none" if k in [] else "regular")
         )
         tx = optax.multi_transform(


### PR DESCRIPTION
This PR adds several small tweaks to the HiPPO calculations and S4 parameterization that bring it in line with the official repo.

- Fix indexing on HiPPO matrix (the index should go from 0 to N-1 instead of 1 to N)
- Initialize the B matrix to HiPPO B matrix
- Tie P and Q vectors together (proposed by SaShiMi, ensures stability)
- Fix variance on C initialization (should be normal() instead of lecun_normal(), explained in "How to Train Your HiPPO" preprint)
- Create HiPPO initializer that constructs the right A/B matrix, allowing the S4 parameters to be trainaed
- Refactor HiPPO calculation to separate NPLR and DPLR calculations
