### PR TITLE
Improve HiPPO diagonalization

### DIFF
--- a/s4/dss.py
+++ b/s4/dss.py
@@ -427,8 +427,10 @@ class DSSLayer(nn.Module):
 
     def setup(self):
         # Learned Parameters
-        hippo_Lambda_initializer, _, _ = s4.hippo_initializer(self.N)
-        self.Lambda = self.param("Lambda", hippo_Lambda_initializer, (self.N,))
+        hippo_Lambda_real_initializer, hippo_Lambda_imag_initializer, hippo_p_initializer, hippo_B_initializer = s4.hippo_initializer(self.N)
+        self.Lambda_re = self.param("Lambda_re", hippo_Lambda_real_initializer, (self.N,))
+        self.Lambda_im = self.param("Lambda_im", hippo_Lambda_imag_initializer, (self.N,))
+        self.Lambda = self.Lambda_re + 1j*self.Lambda_im
         self.W = self.param("W", lecun_normal(), (1, self.N, 2))
         self.W = self.W[..., 0] + 1j * self.W[..., 1]
         self.D = self.param("D", nn.initializers.ones, (1,))

--- a/s4/s4.py
+++ b/s4/s4.py
@@ -1213,7 +1213,9 @@ class S4Layer(nn.Module):
         hippo_Lambda_real_initializer, hippo_Lambda_imag_initializer, hippo_p_initializer, hippo_B_initializer = hippo_initializer(self.N)
         self.Lambda_re = self.param("Lambda_re", hippo_Lambda_real_initializer, (self.N,))
         self.Lambda_im = self.param("Lambda_im", hippo_Lambda_imag_initializer, (self.N,))
-        self.Lambda = np.clip(self.Lambda_re, None, 0.0) + 1j*self.Lambda_im
+        # Ensure the real part of Lambda is negative
+        # (described in the SaShiMi follow-up to S4)
+        self.Lambda = np.clip(self.Lambda_re, None, -1e-4) + 1j*self.Lambda_im
         self.p = self.param("p", hippo_p_initializer, (self.N,))
         self.B = self.param("B", hippo_B_initializer, (self.N, 1))
         # C should be init as standard normal

--- a/s4/train.py
+++ b/s4/train.py
@@ -102,13 +102,13 @@ def create_train_state(
         #   > Solution: Use Optax.multi_transform!
         s4_fn = map_nested_fn(
             lambda k, _: "s4"
-            if k in ["Lambda", "p", "B", "log_step", "W"]
+            if k in ["Lambda", "Lambda_re", "Lambda_im", "p", "B", "W"]
             else ("none" if k in [] else "regular")
         )
         tx = optax.multi_transform(
             {
                 "none": optax.sgd(learning_rate=0.0),
-                "s4": optax.adam(learning_rate=1e-3),
+                "s4": optax.adam(learning_rate=min(1e-3, lr)),
                 "regular": optax.adamw(learning_rate=lr, weight_decay=0.01),
             },
             s4_fn,


### PR DESCRIPTION
This fixes the problem that required the DPLR representation to be constructed on CPU, because it requires a diagonalization call to `jnp.linalg.eig` that is currently not supported on GPU.

- The main idea is that multiplying the skew-symmetric part of the HiPPO matrix by i turns it into a Hermitian matrix, and we can then call `eigh` which is more stable and faster than `eig`, and works on GPU with JAX.
- This is equivalent to computing the imaginary part of `Lambda` separately
- We also enforce a simple clipping to make the real part of `Lambda` negative, proposed by SaShiMi and is important for stability of SSMs at generation time