### PR TITLE
Handle special learning rates better

### DIFF
--- a/s4/dss.py
+++ b/s4/dss.py
@@ -425,6 +425,12 @@ class DSSLayer(nn.Module):
     l_max: int
     decode: bool = False
 
+    lr = {
+        "Lambda_re": 0.1,
+        "Lambda_im": 0.1,
+        "log_step": 0.1,
+    }
+
     def setup(self):
         # Learned Parameters
         hippo_Lambda_real_initializer, hippo_Lambda_imag_initializer, hippo_p_initializer, hippo_B_initializer = s4.hippo_initializer(self.N)

--- a/s4/dss.py
+++ b/s4/dss.py
@@ -462,10 +462,6 @@ class DSSLayer(nn.Module):
                 self.x_k_1.value = x_k
             return y_s.reshape(-1).real + self.D * u
 
-def DSSLayerInit(N):
-    return partial(DSSLayer, N=N)
-
-
 DSSLayer = s4.cloneLayer(DSSLayer)
 
 

--- a/s4/s4.py
+++ b/s4/s4.py
@@ -1220,6 +1220,15 @@ class S4Layer(nn.Module):
     l_max: int
     decode: bool = False
 
+    # Special parameters with multiplicative factor on lr and no weight decay (handled by main train script)
+    lr = {
+        "Lambda_re": 0.1,
+        "Lambda_im": 0.1,
+        "P": 0.1,
+        "B": 0.1,
+        "log_step": 0.1,
+    }
+
     def setup(self):
         # Learned Parameters (Ct is complex!)
         hippo_Lambda_real_initializer, hippo_Lambda_imag_initializer, hippo_p_initializer, hippo_B_initializer = hippo_initializer(self.N)

--- a/s4/train.py
+++ b/s4/train.py
@@ -121,6 +121,12 @@ def create_train_state(
     # tx = optax.adamw(learning_rate=lr, weight_decay=0.01)
 
 
+    # Print parameter count
+    param_sizes = map_nested_fn(
+        lambda k, param: param.size if lr_layer.get(k, lr) > 0. else 0
+    )(params)
+    print(f"[*] Trainable Parameters: {sum(jax.tree_leaves(param_sizes))}")
+    print(f"[*] Total training steps: {total_steps}")
 
     return train_state.TrainState.create(
         apply_fn=model.apply, params=params, tx=tx

--- a/s4/train.py
+++ b/s4/train.py
@@ -9,7 +9,7 @@ from flax.training import checkpoints, train_state
 from tqdm import tqdm
 from .data import Datasets
 from .dss import DSSLayerInit
-from .s4 import BatchStackedModel, S4LayerInit, SSMInit
+from .s4 import BatchStackedModel, S4LayerInit, SSMLayerInit
 
 
 try:
@@ -264,7 +264,7 @@ class LSTMRecurrentModel(nn.Module):
 Models = {
     "ff": FeedForwardModel,
     "lstm": LSTMRecurrentModel,
-    "ssm-naive": SSMInit,
+    "ssm-naive": SSMLayerInit,
     "s4": S4LayerInit,
     "dss": DSSLayerInit,
 }

--- a/s4/train.py
+++ b/s4/train.py
@@ -122,8 +122,10 @@ def create_train_state(
 
 
     # Print parameter count
+    _is_complex = lambda x: x.dtype in [np.complex64, np.complex128]
     param_sizes = map_nested_fn(
-        lambda k, param: param.size if lr_layer.get(k, lr) > 0. else 0
+        lambda k, param: param.size * (2 if _is_complex(param) else 1)
+        if lr_layer.get(k, lr) > 0. else 0
     )(params)
     print(f"[*] Trainable Parameters: {sum(jax.tree_leaves(param_sizes))}")
     print(f"[*] Total training steps: {total_steps}")


### PR DESCRIPTION
This PR makes a pretty large change to the way special hyperparameters are handled. Instead of being controlled by the global training loop (`train.py` has to specify the special parameters and their hyperparameters), it's better to have the models locally handle their own hyperparameters.

This required several changes to make. The idea is that each Flax nn.Module should just store a dictionary of its hyperparameters. For example, `S4Layer` defines
```
lr = {
    "Lambda_re": 0.1,
    "Lambda_im": 0.1,
    "P": 0.1,
    "B": 0.1,
    "log_step": 0.1,
}
```
which says that it wants each of these hyperparameters to have LR scaled by 0.1. (All special parameters also have weight decay set to 0). The optimizer constructor simply has to grab `model_cls.lr` from the core Module layer to get access to these.

--------------------------

However, these Modules were actually previously handled by another layer of indirection, through the `SSLayerInit` functions which passed things like `N` and initializations into a `partial` call, e.g.
```
def SSMInit(N):
    return partial(cloneLayer(SSMLayer), A=make_HiPPO(N), N=N)
```
Thus the actual layer constructors were not the original nn.Module, but wrapped `partial` calls that lost access to the `lr` attribute.

--------------------------

In general this design seems suboptimal, so the first change is to get rid of these partial constructors. Instead, the `N` value has to be passed directly into the layer. This leads to another problem: the layer is wrapped inside several other modules e.g. (`SequenceBlock`, `StackedModule`, and `BatchStackedModule`) which must handle all the potential options of the inside layer. Instead, I gave them a `layer_args` parameter to pass directly into the core layer constructor. This would hold things like `N`, `l_max`, and anything else that only the layer needs.

--------------------------

A second problem is that the vanilla `SSMLayer` was defined with the HiPPO A matrix, as shown above. This was sort of a special case that's annoying to handle, as we don't want to construct `layer_args["A"] = make_hippo()` only for this class. Thus I decided to just get rid of the HiPPO init from the vanilla SSMLayer entirely and randomly initialize A. This required changing the blog post, because it defined HiPPO first then this `SSMLayer`.

So I defined `SSMLayer` as a generic SSM and moved the HiPPO definition into a Part 1b afterwards. Actually, I think this is cleaner from the perspective of the S4 story as well. It makes sense to define SSMs in general and then talk about how S4 is different (modeling side: use HiPPO; computational side: use DPLR)

--------------------------

- Finally, there was a bug in the original code where the LR schedulers weren't handled correctly for the special parameters. The new code takes care of all of this in a cleaner way.
- We can also add trainable parameter counts using the same ideas