### PR TITLE
Fix WandB logging

### DIFF
--- a/s4/dss.py
+++ b/s4/dss.py
@@ -34,14 +34,16 @@
 # Space (DSS) variant can be easily implemented in PyTorch with some minor changes.
 
 # import s4.s4 as s4  TODO -- For some reason breaks streamlit...
-import s4
+from . import s4
 from functools import partial
 import jax
 import jax.numpy as np
 from flax import linen as nn
 from jax.nn.initializers import lecun_normal, normal
 
-rng = jax.random.PRNGKey(1)
+
+if __name__ == '__main__':
+    rng = jax.random.PRNGKey(1)
 
 # ## Table of Contents
 # <nav id="TOC">

--- a/s4/dss.py
+++ b/s4/dss.py
@@ -333,9 +333,6 @@ def test_conversion(N=8, L=16):
     assert np.allclose(y1, y2.reshape(-1).real, atol=1e-4, rtol=1e-4)
 
 
-test_conversion()
-
-
 # ### Secret Sauce – Part 1: Complex Softmax
 #
 # While the implementation above is pretty concise, there are some subtle gotchas that need to be addresed. First is the

--- a/s4/s4.py
+++ b/s4/s4.py
@@ -100,7 +100,10 @@ from jax.numpy.linalg import eigh, inv, matrix_power
 from jax.scipy.signal import convolve
 
 
-rng = jax.random.PRNGKey(1)
+if __name__ == '__main__':
+    # For this tutorial, it'll be convenient to construct a global rng key
+    # But we don't want it when importing as a library
+    rng = jax.random.PRNGKey(1)
 
 
 # ## Part 1: State Space Models

--- a/s4/s4d.py
+++ b/s4/s4d.py
@@ -45,7 +45,7 @@ import jax
 import jax.numpy as np
 from flax import linen as nn
 from jax.nn.initializers import lecun_normal, normal
-from s4 import (
+from .s4 import (
     causal_convolution,
     cloneLayer,
     hippo_initializer,
@@ -55,7 +55,8 @@ from s4 import (
 )
 
 
-rng = jax.random.PRNGKey(1)
+if __name__ == '__main__':
+    rng = jax.random.PRNGKey(1)
 
 # ## Table of Contents
 # <nav id="TOC">

--- a/s4/train.py
+++ b/s4/train.py
@@ -312,18 +312,12 @@ def example_train(
     n_layers=4,
     p_dropout=0.2,
     suffix=None,
-    use_wandb=True,
-    wandb_project="s4",
-    wandb_entity=None,
     checkpoint=False,
 ):
     # Set randomness...
     print("[*] Setting Randomness...")
     key = jax.random.PRNGKey(0)
     key, rng, train_rng = jax.random.split(key, num=3)
-
-    if use_wandb:
-        wandb.init(project=wandb_project, entity=wandb_entity)
 
     # Check if classification dataset
     classification = "classification" in dataset
@@ -420,7 +414,7 @@ def example_train(
             f" {best_acc:.4f} at Epoch {best_epoch + 1}\n"
         )
 
-        if use_wandb:
+        if wandb is not None:
             wandb.log(
                 {
                     "Training Loss": train_loss,
@@ -462,9 +456,7 @@ if __name__ == "__main__":
 
     # Weights and Biases Parameters
     parser.add_argument(
-        "--use_wandb",
-        default=False,
-        type=bool,
+        "--wandb", action="store_true",
         help="Whether to use W&B for metric logging",
     )
     parser.add_argument(
@@ -484,6 +476,12 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    if args.wandb:
+        wandb.init(project=args.wandb_project, entity=args.wandb_entity)
+    else:
+        wandb = None
+
+
     example_train(
         args.model,
         args.dataset,
@@ -497,8 +495,5 @@ if __name__ == "__main__":
         n_layers=args.n_layers,
         p_dropout=args.p_dropout,
         suffix=args.suffix,
-        use_wandb=args.use_wandb,
-        wandb_project=args.wandb_project,
-        wandb_entity=args.wandb_entity,
         checkpoint=args.checkpoint,
     )


### PR DESCRIPTION
`wandb.init` seems to bug when there's not enough GPU memory: https://github.com/wandb/client/issues/3758

We just need to move the call to before any JAX operations, which preallocates memory: https://jax.readthedocs.io/en/latest/gpu_memory_allocation.html

This also turns off global operations like setting prng keys inside library files, which actually happens 4 times in the `src.train` script